### PR TITLE
Option to ignore certificate errors, Login with username and Fix GitHub typos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ RUN mvn clean package
 
 FROM sonatype/nexus3:3.10.0
 USER root
-RUN mkdir -p /opt/sonatype/nexus/system/fr/auchan/nexus3-gitlabauth-plugin/1.1.0/
-COPY --from=builder /build/target/nexus3-gitlabauth-plugin-1.1.0.jar /opt/sonatype/nexus/system/fr/auchan/nexus3-gitlabauth-plugin/1.1.0/
-COPY --from=builder /build/target/feature/feature.xml /opt/sonatype/nexus/system/fr/auchan/nexus3-gitlabauth-plugin/1.1.0/nexus3-gitlabauth-plugin-1.1.0-features.xml
-COPY --from=builder /build/pom.xml /opt/sonatype/nexus/system/fr/auchan/nexus3-gitlabauth-plugin/1.1.0/nexus3-gitlabauth-plugin-1.1.0.pom
-RUN echo '<?xml version="1.0" encoding="UTF-8"?><metadata><groupId>fr.auchan</groupId><artifactId>nexus3-gitlabauth-plugin</artifactId><versioning><release>1.1.0</release><versions><version>1.1.0</version></versions><lastUpdated>20170630132608</lastUpdated></versioning></metadata>' > /opt/sonatype/nexus/system/fr/auchan/nexus3-gitlabauth-plugin/maven-metadata-local.xml
-RUN echo "mvn\:fr.auchan/nexus3-gitlabauth-plugin/1.1.0 = 200" >> /opt/sonatype/nexus/etc/karaf/startup.properties
+RUN mkdir -p /opt/sonatype/nexus/system/fr/auchan/nexus3-gitlabauth-plugin/1.1.1/
+COPY --from=builder /build/target/nexus3-gitlabauth-plugin-1.1.1.jar /opt/sonatype/nexus/system/fr/auchan/nexus3-gitlabauth-plugin/1.1.1/
+COPY --from=builder /build/target/feature/feature.xml /opt/sonatype/nexus/system/fr/auchan/nexus3-gitlabauth-plugin/1.1.1/nexus3-gitlabauth-plugin-1.1.1-features.xml
+COPY --from=builder /build/pom.xml /opt/sonatype/nexus/system/fr/auchan/nexus3-gitlabauth-plugin/1.1.1/nexus3-gitlabauth-plugin-1.1.1.pom
+RUN echo '<?xml version="1.0" encoding="UTF-8"?><metadata><groupId>fr.auchan</groupId><artifactId>nexus3-gitlabauth-plugin</artifactId><versioning><release>1.1.1</release><versions><version>1.1.1</version></versions><lastUpdated>20170630132608</lastUpdated></versioning></metadata>' > /opt/sonatype/nexus/system/fr/auchan/nexus3-gitlabauth-plugin/maven-metadata-local.xml
+RUN echo "mvn\:fr.auchan/nexus3-gitlabauth-plugin/1.1.1 = 200" >> /opt/sonatype/nexus/etc/karaf/startup.properties
 
 USER nexus

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Create `/opt/sonatype/nexus/etc/gitlabauth.properties`
 
 Within the file you can configure the following properties:
 
-|Property        |Description                              |[Default](https://github.com/larscheid-schmitzhermes/nexus3-gitlabauth-plugin/blob/master/src/main/java/fr/auchan/nexus3/github/oauth/plugin/configuration/GithubOauthConfiguration.java)|
+|Property        |Description                              |[Default](https://github.com/auchanretailfrance/nexus3-gitlabauth-plugin/blob/master/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/config/GitlabAuthConfiguration.java)|
 |---             |---                                      |---    |
 |`gitlab.api.url`|URL of the Gitlab API to operate against.|`https://gitlab.com`|
 |`gitlab.api.key`|An admin sudo API key to list groups of users.|

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The following lines will:
 - add the plugin to the `karaf` `startup.properties`.
 ```shell
 mkdir -p /opt/sonatype/nexus/system/fr/auchan/ &&\
-wget -O /opt/sonatype/nexus/system/fr/auchan/nexus3-gitlabauth-plugin-1.1.0.jar https://github.com/auchanretailfrance/nexus3-gitlabauth-plugin/releases/download/1.1.0/nexus3-gitlabauth-plugin-1.1.0.jar &&\
-echo "mvn\:fr.auchan/nexus3-gitlabauth-plugin/1.1.0 = 200" >> /opt/sonatype/nexus/etc/karaf/startup.properties
+wget -O /opt/sonatype/nexus/system/fr/auchan/nexus3-gitlabauth-plugin-1.1.1.jar https://github.com/auchanretailfrance/nexus3-gitlabauth-plugin/releases/download/1.1.1/nexus3-gitlabauth-plugin-1.1.1.jar &&\
+echo "mvn\:fr.auchan/nexus3-gitlabauth-plugin/1.1.1 = 200" >> /opt/sonatype/nexus/etc/karaf/startup.properties
 ```
 
 #### 2. Create configuration
@@ -55,12 +55,14 @@ Within the file you can configure the following properties:
 |Property        |Description                              |[Default](https://github.com/auchanretailfrance/nexus3-gitlabauth-plugin/blob/master/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/config/GitlabAuthConfiguration.java)|
 |---             |---                                      |---    |
 |`gitlab.api.url`|URL of the Gitlab API to operate against.|`https://gitlab.com`|
+|`gitlab.api.certificate.ignore_errors`|Ignore certificate errors against `gitlab.api.url`.|`false`|
 |`gitlab.api.key`|An admin sudo API key to list groups of users.|
 |`gitlab.principal.cache.ttl`|[Java Duration](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-) for how long a given Access will be cached for. This is a tradeoff of how quickly access can be revoked and how quickly a Gitlab API will be called!|`PT1M` (1 Minute)|----|
 
 This is what an example file would look like:
 ```properties
 gitlab.api.url=https://gitlab.com
+gitlab.api.certificate.ignore_errors=false
 gitlab.api.key=XXXXXXXXXXXXXXXXXXXXX
 gitlab.principal.cache.ttl=PT1M
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.gitlab</groupId>
             <artifactId>java-gitlab-api</artifactId>
-            <version>4.0.0</version>
+            <version>4.1.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>fr.auchan</groupId>
     <artifactId>nexus3-gitlabauth-plugin</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.1</version>
 
     <parent>
         <groupId>org.sonatype.nexus.plugins</groupId>

--- a/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/api/GitlabApiClient.java
+++ b/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/api/GitlabApiClient.java
@@ -50,6 +50,7 @@ public class GitlabApiClient {
     @PostConstruct
     public void init() {
         client = GitlabAPI.connect(configuration.getGitlabApiUrl(), configuration.getGitlabApiKey());
+        client.ignoreCertificateErrors(configuration.getGitlabIgnoreCertificateErrors());
         initPrincipalCache();
     }
 
@@ -79,6 +80,7 @@ public class GitlabApiClient {
         List<GitlabGroup> groups = null;
         try {
             GitlabAPI gitlabAPI = GitlabAPI.connect(configuration.getGitlabApiUrl(), String.valueOf(token));
+            gitlabAPI.ignoreCertificateErrors(configuration.getGitlabIgnoreCertificateErrors());
             gitlabUser = gitlabAPI.getUser();
         } catch (Exception e) {
             throw new GitlabAuthenticationException(e);

--- a/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/api/GitlabApiClient.java
+++ b/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/api/GitlabApiClient.java
@@ -86,14 +86,18 @@ public class GitlabApiClient {
             throw new GitlabAuthenticationException(e);
         }
 
-        if (gitlabUser==null || !loginName.equals(gitlabUser.getEmail())) {
-            throw new GitlabAuthenticationException("Given username not found or does not match GitLab Username!");
+        if (gitlabUser == null) {
+            throw new GitlabAuthenticationException("Given username not found!");
+        }
+
+        if ( ! loginName.equals(gitlabUser.getUsername()) && ! loginName.equals(gitlabUser.getEmail())) {
+            throw new GitlabAuthenticationException("Given username does not match GitLab username or email!");
         }
 
         GitlabPrincipal principal = new GitlabPrincipal();
 
-        principal.setUsername(gitlabUser.getEmail());
-        principal.setGroups(getGroups((gitlabUser.getUsername())));
+        principal.setUsername(gitlabUser.getUsername());
+        principal.setGroups(getGroups(gitlabUser.getUsername()));
 
         return principal;
     }

--- a/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/api/GitlabApiClient.java
+++ b/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/api/GitlabApiClient.java
@@ -85,7 +85,7 @@ public class GitlabApiClient {
         }
 
         if (gitlabUser==null || !loginName.equals(gitlabUser.getEmail())) {
-            throw new GitlabAuthenticationException("Given username not found or does not match Github Username!");
+            throw new GitlabAuthenticationException("Given username not found or does not match GitLab Username!");
         }
 
         GitlabPrincipal principal = new GitlabPrincipal();

--- a/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/config/GitlabAuthConfiguration.java
+++ b/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/config/GitlabAuthConfiguration.java
@@ -53,7 +53,7 @@ public class GitlabAuthConfiguration {
     }
 
     public Boolean getGitlabIgnoreCertificateErrors() {
-+       return configuration.getProperty(GITLAB_IGNORE_CERTIFICATE_ERRORS, DEFAULT_IGNORE_CERTIFICATE_ERRORS).equals("true");
+        return configuration.getProperty(GITLAB_IGNORE_CERTIFICATE_ERRORS, DEFAULT_IGNORE_CERTIFICATE_ERRORS).equals("true");
      }
 
     public String getGitlabApiKey() {

--- a/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/config/GitlabAuthConfiguration.java
+++ b/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/config/GitlabAuthConfiguration.java
@@ -23,7 +23,11 @@ public class GitlabAuthConfiguration {
 
     private static final String DEFAULT_GITLAB_URL = "https://gitlab.com";
 
+    private static final String DEFAULT_IGNORE_CERTIFICATE_ERRORS = "false";
+
     private static final String GITLAB_API_URL_KEY = "gitlab.api.url";
+
+    private static final String GITLAB_IGNORE_CERTIFICATE_ERRORS = "gitlab.api.certificate.ignore_errors";
 
     private static final String GITLAB_SUDO_API_KEY_KEY = "gitlab.api.key";
 
@@ -47,6 +51,10 @@ public class GitlabAuthConfiguration {
     public String getGitlabApiUrl() {
         return configuration.getProperty(GITLAB_API_URL_KEY, DEFAULT_GITLAB_URL);
     }
+
+    public Boolean getGitlabIgnoreCertificateErrors() {
++       return configuration.getProperty(GITLAB_IGNORE_CERTIFICATE_ERRORS, DEFAULT_IGNORE_CERTIFICATE_ERRORS).equals("true");
+     }
 
     public String getGitlabApiKey() {
         return configuration.getProperty(GITLAB_SUDO_API_KEY_KEY);

--- a/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/config/GitlabAuthConfiguration.java
+++ b/src/main/java/fr/auchan/nexus3/gitlabauth/plugin/config/GitlabAuthConfiguration.java
@@ -27,7 +27,7 @@ public class GitlabAuthConfiguration {
 
     private static final String GITLAB_SUDO_API_KEY_KEY = "gitlab.api.key";
 
-    private static final String GITLAB_PRINCIPAL_CACHE_TTL_KEY = "github.principal.cache.ttl";
+    private static final String GITLAB_PRINCIPAL_CACHE_TTL_KEY = "gitlab.principal.cache.ttl";
     
     private static final Logger LOGGER = LoggerFactory.getLogger(GitlabAuthConfiguration.class);
 
@@ -40,7 +40,7 @@ public class GitlabAuthConfiguration {
         try {
             configuration.load(Files.newInputStream(Paths.get(".", "etc", CONFIG_FILE)));
         } catch (IOException e) {
-            LOGGER.warn("Error reading github oauth properties, falling back to default configuration", e);
+            LOGGER.warn("Error reading GitLab oauth properties, falling back to default configuration", e);
         }
     }
 


### PR DESCRIPTION
The proposed changes are:
- Add an option to ignore certificate errors against GitLab installed with a self signed certificate.
- Bump `java-gitlab-api` from _4.0.0_ to _4.1.0_.
- Fix "GitHub" typos.
- Allow login via username (in addition to the email address). Bump the artifact version to _1.1.1_ (bugfix) because the README mentions two times that it should have behaved this way: 
  - _The plugin does not implement a full OAuth flow, instead you **use your gitlab user name** + an gitlab read_user token you generated in your account to log in to the nexus. This works through the web as well as through tools like maven, gradle etc._
  - _When logging in to nexus, **use your gitlab user name** as the username and the token you just generated as the password. This also works through maven, gradle etc._
